### PR TITLE
Switch to /bin/bash so we can use pipefail option

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,8 @@
   shell: |
     set -o pipefail
     gnome-shell --version | sed 's/[^0-9.]*\([0-9.]*\).*/\1/'
+  args:
+    executable: /bin/bash
   register: gnome_shell_version
   changed_when: no
 


### PR DESCRIPTION
The default interpreter for shell module is /bin/sh, which does not support pipefail, so Ansible fails.